### PR TITLE
gcc: Work around broken bootstrap with Xcode 6.3

### DIFF
--- a/files/brews/gcc48.rb
+++ b/files/brews/gcc48.rb
@@ -104,6 +104,9 @@ class Gcc48 < Formula
       "--enable-stage1-checking",
       "--enable-checking=release",
       "--enable-lto",
+      # Use 'bootstrap-debug' build configuration to force stripping of object
+      # files prior to comparison during bootstrap (broken by Xcode 6.3).
+      "--with-build-config=bootstrap-debug",
       # A no-op unless --HEAD is built because in head warnings will
       # raise errors. But still a good idea to include.
       "--disable-werror",


### PR DESCRIPTION
There's an issue that prevents gcc being compiled successfully with Xcode 6.3

[Details](https://github.com/Homebrew/homebrew/issues/38501)

[There's a workaround described here](https://github.com/Homebrew/homebrew/issues/38501#issuecomment-91678230)

**Excerpt**

---

> I have no proper solution, but I can offer an explanation and a workaround.
> 
> **Explanation:** Building GCC usually means building several intermediate compilers, i.e. the host compiler (Clang on OS X) builds a stage 1 GCC. Stage 1 then builds stage 2 and stage 2 builds stage 3. To ensure that the built compiler is not broken, the build system compares the object files of stage 2 and 3, which fails with Xcode 6.3 and/or OS X 10.10.3 (not sure what the culprit is). Excerpt from 02.make (unfortunately several lines above the output from Homebrew):
> 
> ```
> Comparing stages 2 and 3
> warning: gcc/cc1-checksum.o differs
> warning: gcc/cc1obj-checksum.o differs
> warning: gcc/cc1objplus-checksum.o differs
> warning: gcc/cc1plus-checksum.o differs
> Bootstrap comparison failure!
> gcc/asan.o differs
> gcc/attribs.o differs
> […]
> ```
> 
> The thing is, the object files are indeed different, but the difference is only to be found in the debug information (it is equivalent, but not bit-for-bit identical). On the other hand, the actual machine code is indeed bit-for-bit identical, as can be seen by stripping the object files.
> 
> **Workaround**: The trick is to use the knowledge from the explanation above and to instruct the GCC build system to compare stripped object files, by passing the additional configure flag --with-build-config=bootstrap-debug (see https://gcc.gnu.org/install/build.html for details). This should go somewhere into the args array in [gcc.rb](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/gcc.rb#L87-109) (line 87-109).

---
